### PR TITLE
fix: Assign default attributes to all resources in the compiled CloudFormation template

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@ const _ = {
 class DefaultAwsAttributes {
   constructor(serverless) {
     this.provider = serverless.getProvider('aws');
-    this.serverless = serverless.service;
+    this.serverless = serverless;
     this.hooks = {
-      'before:package:finalize': this.addDefaults.bind(this)
+      'aws:package:finalize:mergeCustomProviderResources': this.addDefaults.bind(this)
     };
   }
 
   getDefaults() {
-    return this.serverless.custom.defaultAwsAttributes || {};
+    return this.serverless.service.custom.defaultAwsAttributes || {};
   }
 
   mergeAttributes({ original, additional }) {
@@ -32,7 +32,7 @@ class DefaultAwsAttributes {
         {}
       );
 
-    const resources = this.serverless.resources.Resources;
+    const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
     for(const logicalId of Object.keys(resources)) {
       const { Type } = resources[logicalId];


### PR DESCRIPTION
Currently this plugin only assigns defined default attributes to items listed under `resources.Resources`, and not resources generated by the serverless framework or other plugins.

Currently, say if I have alarms defined by another plugin, i.e. serverless-plugin-aws-alerts, the resources generated by that plugin do not get default attributes that this plugin would be assigning to their resource type as the resources aren't manually defined under `resources.Resources`, i.e.

```yaml
    - Type: AWS::CloudWatch::Alarm
      Metadata:
        cfn_nag:
          rules_to_suppress:
            - id: W28
```

These changes apply the defaultAwsAttributes to all resources in the compiled template, which includes resources generated by other plugins.

Compiling and then comparing the templates (`.serverless/cloudformation-template-update-stack.json`) before/after the change shows the expected results